### PR TITLE
Little improvement on auto_follow_followers and auto_unfollow_followers

### DIFF
--- a/TwitterFollowBot/__init__.py
+++ b/TwitterFollowBot/__init__.py
@@ -284,7 +284,7 @@ class TwitterBot:
                 if "already requested to follow" not in str(api_error).lower():
                     print("Error: %s" % (str(api_error)), file=sys.stderr)
 
-    def auto_follow_followers(self):
+    def auto_follow_followers(self,count=None):
         """
             Follows back everyone who's followed you.
         """
@@ -293,7 +293,7 @@ class TwitterBot:
         followers = self.get_followers_list()
 
         not_following_back = followers - following
-
+        not_following_back = not_following_back[:count]
         for user_id in not_following_back:
             try:
                 self.TWITTER_CONNECTION.friendships.create(user_id=user_id, follow=False)
@@ -339,7 +339,7 @@ class TwitterBot:
                 if "already requested to follow" not in str(api_error).lower():
                     print("Error: %s" % (str(api_error)), file=sys.stderr)
 
-    def auto_unfollow_nonfollowers(self):
+    def auto_unfollow_nonfollowers(self,count=None):
         """
             Unfollows everyone who hasn't followed you back.
         """
@@ -348,7 +348,7 @@ class TwitterBot:
         followers = self.get_followers_list()
 
         not_following_back = following - followers
-
+        not_following_back = not_following_back[:count]
         # update the "already followed" file with users who didn't follow back
         already_followed = set(not_following_back)
         already_followed_list = []


### PR DESCRIPTION
-  From #47
- Set a limit on auto_follow and auto_unfollow.
- While not parameter ````count````sent will execute all the possibilities (Default bot).